### PR TITLE
Accept readonly arrays as JSON values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type ObjectDict<T = unknown> = Record<string, T | undefined>;
 export type JSONPrimitive = string | number | boolean | null;
 export type JSONValue = JSONPrimitive | JSONObject | JSONArray;
 export type JSONObject = { [member: string]: JSONValue };
-export type JSONArray = JSONValue[];
+export type JSONArray = readonly JSONValue[];
 
 export const TYPE_ANY = InputArgument.TYPE_ANY;
 export const TYPE_ARRAY = InputArgument.TYPE_ARRAY;


### PR DESCRIPTION
This allows things like `search(['a'] as const, '[0]')`. Previously that would be rejected by the type checker.