### PR TITLE
[JEP-11] Lexical Scoping

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -65,6 +65,8 @@ export interface ComparitorNode extends ExpressionNode {
   name: Token;
 }
 
+export type ExpressionReference = { context: JSONValue } & ExpressionNode;
+
 export type ExpressionNodeTree = ASTNode | ExpressionNode | FieldNode | ValueNode;
 
 export const basicTokens: Record<string, Token> = {

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,5 +1,6 @@
 import {
   ComparitorNode,
+  ExpressionReference,
   ExpressionNode,
   ExpressionNodeTree,
   FieldNode,
@@ -136,9 +137,10 @@ class TokenParser {
         return { type: Token.TOK_CURRENT };
       case Token.TOK_ROOT:
         return { type: Token.TOK_ROOT };
-      case Token.TOK_EXPREF:
-        expression = this.expression(bindingPower.Expref);
-        return { type: 'ExpressionReference', children: [expression] } as ExpressionNode;
+      case Token.TOK_EXPREF: {
+        const child = this.expression(bindingPower.Expref);
+        return { type: 'ExpressionReference', children: [child] } as ExpressionReference;
+      }
       case Token.TOK_LPAREN:
         const args: ASTNode[] = [];
         while (this.lookahead(0) !== Token.TOK_RPAREN) {

--- a/src/Runtime.ts
+++ b/src/Runtime.ts
@@ -1,5 +1,5 @@
 import type { TreeInterpreter } from './TreeInterpreter';
-import type { ExpressionNode } from './Lexer';
+import type { ExpressionNode, ExpressionReference } from './Lexer';
 import type { JSONValue, JSONObject, JSONArray, ObjectDict } from '.';
 import { Token } from './Lexer';
 
@@ -250,6 +250,11 @@ export class Runtime {
       return inputValue.length;
     }
     return Object.keys(inputValue).length;
+  };
+
+  private functionLet: RuntimeFunction<[JSONObject, ExpressionReference], JSONValue> = ([inputScope, exprefNode]) => {
+    const interpreter = this._interpreter!.withScope(inputScope);
+    return interpreter.visit(exprefNode, exprefNode.context) as JSONValue;
   };
 
   private functionMap = (resolvedArgs: any[]): any[] => {
@@ -568,6 +573,10 @@ export class Runtime {
           types: [InputArgument.TYPE_STRING, InputArgument.TYPE_ARRAY, InputArgument.TYPE_OBJECT],
         },
       ],
+    },
+    let: {
+      _func: this.functionLet,
+      _signature: [{ types: [InputArgument.TYPE_OBJECT] }, { types: [InputArgument.TYPE_EXPREF] }],
     },
     map: {
       _func: this.functionMap,

--- a/src/Scope.ts
+++ b/src/Scope.ts
@@ -1,0 +1,26 @@
+import { JSONObject, JSONValue } from '.';
+
+export class ScopeChain {
+  private inner?: ScopeChain = undefined;
+  private data: JSONObject = {};
+
+  public withScope(data: JSONObject): ScopeChain {
+    const outer: ScopeChain = new ScopeChain();
+    outer.inner = this;
+    outer.data = data;
+    return outer;
+  }
+
+  public getValue(identifier: string): JSONValue {
+    if (identifier in this.data) {
+      const result = this.data?.[identifier];
+      if (result) {
+        return result;
+      }
+    }
+    if (this.inner) {
+      return this.inner.getValue(identifier);
+    }
+    return null;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import Lexer from './Lexer';
 import TreeInterpreterInst from './TreeInterpreter';
 import { ExpressionNodeTree, LexerToken } from './Lexer';
 import { InputArgument, RuntimeFunction, InputSignature } from './Runtime';
+import { ScopeChain } from './Scope';
 
 export type { FunctionSignature, RuntimeFunction, InputSignature } from './Runtime';
 export type ObjectDict<T = unknown> = Record<string, T | undefined>;
@@ -43,6 +44,10 @@ export const registerFunction = (
 export function search(data: JSONValue, expression: string): JSONValue {
   const nodeTree = Parser.parse(expression);
   return TreeInterpreterInst.search(nodeTree, data);
+}
+
+export function Scope(): ScopeChain {
+  return new ScopeChain();
 }
 
 export const TreeInterpreter = TreeInterpreterInst;

--- a/test/compliance/lexical_scoping.json
+++ b/test/compliance/lexical_scoping.json
@@ -1,0 +1,205 @@
+[
+	{
+		"given": {
+			"search_for": "foo",
+			"people": [
+				{
+					"name": "a"
+				},
+				{
+					"name": "b"
+				},
+				{
+					"name": "c"
+				},
+				{
+					"name": "foo"
+				},
+				{
+					"name": "bar"
+				},
+				{
+					"name": "baz"
+				},
+				{
+					"name": "qux"
+				},
+				{
+					"name": "x"
+				},
+				{
+					"name": "y"
+				},
+				{
+					"name": "z"
+				}
+			]
+		},
+		"cases": [
+			{
+				"description": "Let function with filters",
+				"expression": "let({search_for: search_for}, &people[?name==search_for].name | [0])",
+				"result": "foo"
+			}
+		]
+	},
+	{
+		"given": {
+			"a": {
+				"mylist": [
+					{
+						"l1": "1",
+						"result": "foo"
+					},
+					{
+						"l2": "2",
+						"result": "bar"
+					},
+					{
+						"l1": "8",
+						"l2": "9"
+					},
+					{
+						"l1": "8",
+						"l2": "9"
+					}
+				],
+				"level2": "2"
+			},
+			"level1": "1",
+			"nested": {
+				"a": {
+					"b": {
+						"c": {
+							"fourth": "fourth"
+						},
+						"third": "third"
+					},
+					"second": "second"
+				},
+				"first": "first"
+			},
+			"precedence": {
+				"a": {
+					"b": {
+						"c": {
+							"variable": "fourth"
+						},
+						"variable": "third",
+						"other": "y"
+					},
+					"variable": "second",
+					"other": "x"
+				},
+				"variable": "first",
+				"other": "w"
+			}
+		},
+		"cases": [
+			{
+				"description": "Basic let from scope",
+				"expression": "let({level1: level1}, &a.[level2, level1])",
+				"result": [
+					"2",
+					"1"
+				]
+			},
+			{
+				"description": "Current object has precedence",
+				"expression": "let({level1: `\"other\"`}, &level1)",
+				"result": "1"
+			},
+			{
+				"description": "No scope specified using literal hash",
+				"expression": "let(`{}`, &a.level2)",
+				"result": "2"
+			},
+			{
+				"description": "Arbitrary variable added",
+				"expression": "let({foo: `\"anything\"`}, &[level1, foo])",
+				"result": [
+					"1",
+					"anything"
+				]
+			},
+			{
+				"description": "Basic let from current object",
+				"expression": "let({other: level1}, &level1)",
+				"result": "1"
+			},
+			{
+				"description": "Nested let function with filters",
+				"expression": "let({level1: level1}, &a.[mylist[?l1==level1].result, let({level2: level2}, &mylist[?l2==level2].result)])[]",
+				"result": [
+					"foo",
+					"bar"
+				]
+			},
+			{
+				"description": "Nested let function with filters with literal scope binding",
+				"expression": "let(`{\"level1\": \"1\"}`, &a.[mylist[?l1==level1].result, let({level2: level2}, &mylist[?l2==level2].result)])[]",
+				"result": [
+					"foo",
+					"bar"
+				]
+			},
+			{
+				"description": "Nested let functions",
+				"expression": "nested.let({level1: first}, &a.let({level2: second}, &b.let({level3: third}, &c.{first: level1, second: level2, third: level3, fourth: fourth})))",
+				"result": {
+					"first": "first",
+					"second": "second",
+					"third": "third",
+					"fourth": "fourth"
+				}
+			},
+			{
+				"description": "Precedence of lexical vars from scope object",
+				"expression": "precedence.let({other: other}, &a.let({other: other}, &b.let({other: other}, &c.{other: other})))",
+				"result": {
+					"other": "y"
+				}
+			},
+			{
+				"description": "Precedence of lexical vars from current object",
+				"expression": "precedence.let({variable: variable}, &a.let({variable: variable}, &b.let({variable: variable}, &c.let({variable: `\"override\"`}, &variable))))",
+				"result": "fourth"
+			}
+		]
+	},
+	{
+		"given": {
+			"first_choice": "WA",
+			"states": [
+				{
+					"name": "WA",
+					"cities": [
+						"Seattle",
+						"Bellevue",
+						"Olympia"
+					]
+				},
+				{
+					"name": "CA",
+					"cities": [
+						"Los Angeles",
+						"San Francisco"
+					]
+				},
+				{
+					"name": "NY",
+					"cities": [
+						"New York City",
+						"Albany"
+					]
+				}
+			]
+		},
+		"cases": [
+			{
+				"expression": "states[?name==$.first_choice].cities[]",
+				"result": ["Seattle", "Bellevue", "Olympia"]
+			}
+		]
+	}
+]

--- a/test/jmespath.spec.js
+++ b/test/jmespath.spec.js
@@ -111,6 +111,10 @@ describe('Searches compiled ast', () => {
     const ast = compile('foo.bar');
     expect(TreeInterpreter.search(ast, { foo: { bar: 'BAZ' } })).toEqual('BAZ');
   });
+  it('should evaluate lexical scope', () => {
+    const ast = compile("let({foo: 'bar'}, &foo)");
+    expect(TreeInterpreter.search(ast, { this: 'is the context' })).toEqual('bar');
+  });
 });
 
 describe('strictDeepEqual', () => {

--- a/test/scopes.spec.js
+++ b/test/scopes.spec.js
@@ -1,0 +1,27 @@
+import { Scope } from '../src';
+
+describe('scopes', () => {
+  it('should return null on missing identifier', () => {
+    const scope = Scope({});
+    expect(scope.getValue('foo')).toEqual(null);
+  });
+  it('should return item from scope', () => {
+    const scope = Scope({});
+    {
+      const outer = scope.withScope({ foo: 'bar' });
+      expect(outer.getValue('foo')).toEqual('bar');
+    }
+  });
+  it('should return item from nested scope', () => {
+    const scope = Scope({});
+    {
+      const outer = scope.withScope({ foo: 'bar', qux: 'quux' });
+      {
+        const inner = outer.withScope({ foo: 'baz' });
+        expect(inner.getValue('foo')).toEqual('baz');
+        expect(inner.getValue('qux')).toEqual('quux');
+      }
+      expect(outer.getValue('foo')).toEqual('bar');
+    }
+  });
+});


### PR DESCRIPTION
This PR implements [lexical scoping](https://github.com/jmespath-community/jmespath.spec/blob/main/jep-011-let-function.md)  and the [`let`](https://jmespath.site/main/#func-let) function from JMESPath Community.

**Warning**: althought this feature is currently implemented in JMESPath Community ports in Python and Golang, it is currently subject to [active discussion](https://github.com/jmespath/jmespath.site/pull/6#issuecomment-1464113092) and may be rendered obsolete.