### PR TITLE
Fix unsupported '\\' raw-string escape sequence.

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -223,7 +223,7 @@ class StreamLexer {
     }
     this._current += 1;
     const literal = stream.slice(start + 1, this._current - 1);
-    return literal.replace(`\\'`, `'`);
+    return literal.replace(`\\'`, `'`).replace(`\\\\`, `\\`);
   }
 
   private consumeNumber(stream: string): LexerToken {

--- a/test/compliance/literal.json
+++ b/test/compliance/literal.json
@@ -207,6 +207,16 @@
         "comment": "Can escape the single quote",
         "expression": "'foo\\'bar'",
         "result": "foo'bar"
+      },
+      {
+        "comment": "Can escape backslash",
+        "expression": "'\\\\'",
+        "result": "\\"
+      },
+      {
+        "comment": "Backslash not followed by single quote is treated as any other character",
+        "expression": "'\\z'",
+        "result": "\\z"
       }
     ]
   }


### PR DESCRIPTION
Fixes: [jmespath.test/#15](https://github.com/jmespath-community/jmespath.test/issues/15)