### PR TITLE
Fixed parsing raw string literals

### DIFF
--- a/src/Lexer.ts
+++ b/src/Lexer.ts
@@ -223,7 +223,12 @@ class StreamLexer {
     }
     this._current += 1;
     const literal = stream.slice(start + 1, this._current - 1);
-    return literal.replace(`\\'`, `'`);
+
+    // emulating es2021: String.prototype.replaceAll()
+    return literal
+      .split(`\\\\`).join(`\\`)
+      .split(`\\'`).join(`'`)
+      ;
   }
 
   private consumeNumber(stream: string): LexerToken {

--- a/test/jmespath.spec.js
+++ b/test/jmespath.spec.js
@@ -50,6 +50,18 @@ describe('tokenize', () => {
   it('should tokenize json literals', () => {
     expect(tokenize('`true`')).toMatchObject([{ type: 'Literal', value: true, start: 0 }]);
   });
+  it('should tokenize raw strings', () => {
+    expect(tokenize("'raw-string'")).toMatchObject([{ type: 'Literal', value: "raw-string", start: 0 }]);
+  });
+  it('should tokenize raw strings single quote', () => {
+    expect(tokenize("'\\''")).toMatchObject([{ type: 'Literal', value: "'", start: 0 }]);
+  });
+  it('should tokenize raw strings surrounding quotes', () => {
+    expect(tokenize("'\\'raw-string\\''")).toMatchObject([{ type: 'Literal', value: "'raw-string'", start: 0 }]);
+  });
+  it('should tokenize raw strings backslash characters', () => {
+    expect(tokenize("'\\\\'")).toMatchObject([{ type: 'Literal', value: "\\", start: 0 }]);
+  });
   it('should not requiring surrounding quotes for strings', () => {
     expect(tokenize('`foo`')).toMatchObject([{ type: 'Literal', value: 'foo', start: 0 }]);
   });


### PR DESCRIPTION
Fixes #42.


> `` search( contains(['wanna be starting something'], a) , {"a": "wanna be starting something"} ) → true ``
> `` search( contains(['wanna be starting somethin\''], a) , {"a": "wanna be starting somethin'"} ) → true ``
> `` search( contains(['wanna be startin\' somethin\''], a) , {"a": "wanna be startin' somethin'"} ) → true ``